### PR TITLE
Extension and refactoring of live templates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 #### 2018-10-25:
+ - [PR#614](https://github.com/BashSupport/BashSupport/pull/614): Extension and refactoring of live templates (contributed by t0r0X)
+
+#### 2018-10-25:
  - [#521](https://github.com/BashSupport/BashSupport/issues/521): control+j does not offer for loop solutions (contributed by t0r0X)
 
 #### 2018-09-27:

--- a/resources/liveTemplates/Bash.xml
+++ b/resources/liveTemplates/Bash.xml
@@ -89,21 +89,24 @@
             <option name="OTHER" value="false"/>
         </context>
     </template>
-	<template name="for-each-in" value="for $LOOPVAR$ in $LOOPITEMS$ ; do&#10;    $END$$SELECTION$&#10;done&#10;" description="&quot;For each in set&quot; loop" toReformat="true" toShortenFQNames="false">
-		<variable name="LOOPVAR" expression="" defaultValue="&quot;VAR&quot;" alwaysStopAt="true"/>
-		<variable name="LOOPITEMS" expression="" defaultValue="&quot;item1 item2 item3&quot;" alwaysStopAt="true"/>
-		<context>
-			<option name="Bash" value="true"/>
+    <template name="for-each-in" value="for $LOOPVAR$ in $LOOPITEMS$ ; do&#10;    $END$$SELECTION$&#10;done&#10;"
+              description="&quot;For each in set&quot; loop" toReformat="true" toShortenFQNames="false">
+        <variable name="LOOPVAR" expression="" defaultValue="&quot;VAR&quot;" alwaysStopAt="true"/>
+        <variable name="LOOPITEMS" expression="" defaultValue="&quot;item1 item2 item3&quot;" alwaysStopAt="true"/>
+        <context>
+            <option name="Bash" value="true"/>
             <option name="OTHER" value="false"/>
-		</context>
-	</template>
-	<template name="for-index" value="for (( $LOOPVAR$ = $LOOPSTART$; $LOOPVAR$ &lt; $LOOPLIMIT$; ++$LOOPVAR$ )); do&#10;    $END$$SELECTION$&#10;done&#10;" description="C-style &quot;for&quot; loop" toReformat="true" toShortenFQNames="false">
-		<variable name="LOOPVAR" expression="" defaultValue="&quot;VAR&quot;" alwaysStopAt="true"/>
-		<variable name="LOOPSTART" expression="" defaultValue="&quot;0&quot;" alwaysStopAt="true"/>
-		<variable name="LOOPLIMIT" expression="" defaultValue="&quot;${LOOP_LIMIT}&quot;" alwaysStopAt="true"/>
-		<context>
-			<option name="Bash" value="true"/>
+        </context>
+    </template>
+    <template name="for-index"
+              value="for (( $LOOPVAR$ = $LOOPSTART$; $LOOPVAR$ &lt; $LOOPLIMIT$; ++$LOOPVAR$ )); do&#10;    $END$$SELECTION$&#10;done&#10;"
+              description="C-style &quot;for&quot; loop" toReformat="true" toShortenFQNames="false">
+        <variable name="LOOPVAR" expression="" defaultValue="&quot;VAR&quot;" alwaysStopAt="true"/>
+        <variable name="LOOPSTART" expression="" defaultValue="&quot;0&quot;" alwaysStopAt="true"/>
+        <variable name="LOOPLIMIT" expression="" defaultValue="&quot;${LOOP_LIMIT}&quot;" alwaysStopAt="true"/>
+        <context>
+            <option name="Bash" value="true"/>
             <option name="OTHER" value="false"/>
-		</context>
-	</template>
+        </context>
+    </template>
 </templateSet>

--- a/resources/liveTemplates/Bash.xml
+++ b/resources/liveTemplates/Bash.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templateSet group="Bash">
-    <template name="if" value="if $test$; then&#10;    $END$&#10;fi" description="if statement" toReformat="false"
+    <template name="if" value="if $TEST$; then&#10;    $SELECTION$$END$&#10;fi" description="if statement" toReformat="false"
               toShortenFQNames="false">
-        <variable name="test" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
+        <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
         <context>
             <option name="Bash" value="true"/>
             <option name="OTHER" value="false"/>
         </context>
     </template>
-    <template name="ife" value="if $test$; then&#10;    $cmd$&#10;else &#10;    $END$&#10;fi"
+    <template name="ife" value="if $TEST$; then&#10;    $SELECTION$$END$&#10;else&#10;    $CMD$&#10;fi"
               description="if-else statement" toReformat="false" toShortenFQNames="false">
-        <variable name="test" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
-        <variable name="cmd" expression="" defaultValue="&quot;echo&quot;" alwaysStopAt="true"/>
+        <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
+        <variable name="CMD" expression="" defaultValue="&quot;echo&quot;" alwaysStopAt="true"/>
         <context>
             <option name="Bash" value="true"/>
             <option name="OTHER" value="false"/>
         </context>
     </template>
-    <template name="while" value="while $test$; do&#10;    $END$&#10;done" description="while-loop" toReformat="false"
+    <template name="while" value="while $TEST$; do&#10;    $SELECTION$$END$&#10;done" description="while-loop" toReformat="false"
               toShortenFQNames="false">
-        <variable name="test" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
+        <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
         <context>
             <option name="Bash" value="true"/>
             <option name="OTHER" value="false"/>
         </context>
     </template>
-    <template name="until" value="until $test$; do&#10;    $END$;&#10;done" description="until-loop" toReformat="false"
+    <template name="until" value="until $TEST$; do&#10;    $SELECTION$$END$&#10;done" description="until-loop" toReformat="false"
               toShortenFQNames="false">
-        <variable name="test" expression="" defaultValue="" alwaysStopAt="true"/>
+        <variable name="TEST" expression="" defaultValue="" alwaysStopAt="true"/>
         <context>
             <option name="Bash" value="true"/>
             <option name="OTHER" value="false"/>
@@ -77,19 +77,18 @@
         </context>
     </template>
     <template name="ifee"
-              value="if $test$; then&#10;    $cmd$&#10;elif $test2$; then&#10;    $cmd2$    &#10;else &#10;    $cmd3$&#10;fi"
+              value="if $TEST$; then&#10;    $SELECTION$$END$&#10;elif $TEST2$; then&#10;    $CMD2$&#10;else&#10;    $CMD3$&#10;fi"
               description="if-elsif-else statement" toReformat="false" toShortenFQNames="false">
-        <variable name="test" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
-        <variable name="cmd" expression="" defaultValue="&quot;echo&quot;" alwaysStopAt="true"/>
-        <variable name="test2" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
-        <variable name="cmd2" expression="" defaultValue="&quot;echo&quot;" alwaysStopAt="true"/>
-        <variable name="cmd3" expression="" defaultValue="echo" alwaysStopAt="true"/>
+        <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
+        <variable name="TEST2" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
+        <variable name="CMD2" expression="" defaultValue="&quot;echo&quot;" alwaysStopAt="true"/>
+        <variable name="CMD3" expression="" defaultValue="&quot;echo&quot;" alwaysStopAt="true"/>
         <context>
             <option name="Bash" value="true"/>
             <option name="OTHER" value="false"/>
         </context>
     </template>
-    <template name="for-each-in" value="for $LOOPVAR$ in $LOOPITEMS$ ; do&#10;    $END$$SELECTION$&#10;done&#10;"
+    <template name="for-each-in" value="for $LOOPVAR$ in $LOOPITEMS$ ; do&#10;    $SELECTION$$END$&#10;done&#10;"
               description="&quot;For each in set&quot; loop" toReformat="true" toShortenFQNames="false">
         <variable name="LOOPVAR" expression="" defaultValue="&quot;VAR&quot;" alwaysStopAt="true"/>
         <variable name="LOOPITEMS" expression="" defaultValue="&quot;item1 item2 item3&quot;" alwaysStopAt="true"/>
@@ -99,7 +98,7 @@
         </context>
     </template>
     <template name="for-index"
-              value="for (( $LOOPVAR$ = $LOOPSTART$; $LOOPVAR$ &lt; $LOOPLIMIT$; ++$LOOPVAR$ )); do&#10;    $END$$SELECTION$&#10;done&#10;"
+              value="for (( $LOOPVAR$ = $LOOPSTART$; $LOOPVAR$ &lt; $LOOPLIMIT$; ++$LOOPVAR$ )); do&#10;    $SELECTION$$END$&#10;done&#10;"
               description="C-style &quot;for&quot; loop" toReformat="true" toShortenFQNames="false">
         <variable name="LOOPVAR" expression="" defaultValue="&quot;VAR&quot;" alwaysStopAt="true"/>
         <variable name="LOOPSTART" expression="" defaultValue="&quot;0&quot;" alwaysStopAt="true"/>

--- a/resources/liveTemplates/Bash.xml
+++ b/resources/liveTemplates/Bash.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templateSet group="Bash">
-    <template name="she" value="#!$ENV$ $BASH$&#10;$END$" description="shebang line" toReformat="false" toShortenFQNames="false">
-        <variable name="ENV" expression="" defaultValue="&quot;/usr/bin/env&quot;" alwaysStopAt="false"/>
-        <variable name="BASH" expression="enum(&quot;bash&quot;,&quot;sh&quot;)" defaultValue="" alwaysStopAt="true"/>
-        <context>
-            <option name="Bash" value="true"/>
-            <option name="OTHER" value="false"/>
-        </context>
-    </template>
     <template name="cas" value="case $value$ in&#10;$pattern$)&#10;  $END$ ;;&#10;esac" description="Case statement"
               toReformat="false" toShortenFQNames="false">
         <variable name="value" expression="" defaultValue="&quot;$x&quot;" alwaysStopAt="true"/>
@@ -38,6 +30,14 @@
               toReformat="false" toShortenFQNames="false">
         <variable name="a" expression="" defaultValue="&quot;$a&quot;" alwaysStopAt="true"/>
         <variable name="b" expression="" defaultValue="&quot;$b&quot;" alwaysStopAt="true"/>
+        <context>
+            <option name="Bash" value="true"/>
+            <option name="OTHER" value="false"/>
+        </context>
+    </template>
+    <template name="func" value="function $FUNCNAME$() {&#10;    $END$$SELECTION$&#10;}" description="Function template"
+              toReformat="true" toShortenFQNames="false">
+        <variable name="FUNCNAME" expression="" defaultValue="" alwaysStopAt="true"/>
         <context>
             <option name="Bash" value="true"/>
             <option name="OTHER" value="false"/>
@@ -87,6 +87,21 @@
         <variable name="LOOPVAR" expression="" defaultValue="&quot;VAR&quot;" alwaysStopAt="true"/>
         <variable name="LOOPSTART" expression="" defaultValue="&quot;0&quot;" alwaysStopAt="true"/>
         <variable name="LOOPLIMIT" expression="" defaultValue="&quot;${LOOP_LIMIT}&quot;" alwaysStopAt="true"/>
+        <context>
+            <option name="Bash" value="true"/>
+            <option name="OTHER" value="false"/>
+        </context>
+    </template>
+    <template name="she" value="#!$ENV$ $BASH$&#10;$END$" description="shebang line" toReformat="false" toShortenFQNames="false">
+        <variable name="ENV" expression="" defaultValue="&quot;/usr/bin/env&quot;" alwaysStopAt="false"/>
+        <variable name="BASH" expression="enum(&quot;bash&quot;,&quot;sh&quot;)" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="Bash" value="true"/>
+            <option name="OTHER" value="false"/>
+        </context>
+    </template>
+    <template name="shebin" value="#!/bin/$SHELL$&#10;$END$" description="shebang line /bin" toReformat="false" toShortenFQNames="false">
+        <variable name="SHELL" expression="enum(&quot;bash&quot;,&quot;sh&quot;)" defaultValue="" alwaysStopAt="true"/>
         <context>
             <option name="Bash" value="true"/>
             <option name="OTHER" value="false"/>

--- a/resources/liveTemplates/Bash.xml
+++ b/resources/liveTemplates/Bash.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templateSet group="Bash">
-    <template name="she" value="#!$ENV$ $BASH$" description="shebang line" toReformat="false" toShortenFQNames="false">
+    <template name="she" value="#!$ENV$ $BASH$&#10;$END$" description="shebang line" toReformat="false" toShortenFQNames="false">
         <variable name="ENV" expression="" defaultValue="&quot;/usr/bin/env&quot;" alwaysStopAt="false"/>
         <variable name="BASH" expression="enum(&quot;bash&quot;,&quot;sh&quot;)" defaultValue="" alwaysStopAt="true"/>
         <context>
@@ -43,7 +43,7 @@
             <option name="OTHER" value="false"/>
         </context>
     </template>
-    <template name="if" value="if $TEST$; then&#10;    $SELECTION$$END$&#10;fi" description="if statement" toReformat="false"
+    <template name="if" value="if $TEST$; then&#10;    $END$$SELECTION$&#10;fi" description="if statement" toReformat="true"
               toShortenFQNames="false">
         <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
         <context>
@@ -51,8 +51,8 @@
             <option name="OTHER" value="false"/>
         </context>
     </template>
-    <template name="ife" value="if $TEST$; then&#10;    $SELECTION$$END$&#10;else&#10;    $CMD$&#10;fi"
-              description="if-else statement" toReformat="false" toShortenFQNames="false">
+    <template name="ife" value="if $TEST$; then&#10;    $END$$SELECTION$&#10;else&#10;    $CMD$&#10;fi"
+              description="if-else statement" toReformat="true" toShortenFQNames="false">
         <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
         <variable name="CMD" expression="" defaultValue="&quot;echo&quot;" alwaysStopAt="true"/>
         <context>
@@ -61,8 +61,8 @@
         </context>
     </template>
     <template name="ifee"
-              value="if $TEST$; then&#10;    $SELECTION$$END$&#10;elif $TEST2$; then&#10;    $CMD2$&#10;else&#10;    $CMD3$&#10;fi"
-              description="if-elsif-else statement" toReformat="false" toShortenFQNames="false">
+              value="if $TEST$; then&#10;    $END$$SELECTION$&#10;elif $TEST2$; then&#10;    $CMD2$&#10;else&#10;    $CMD3$&#10;fi"
+              description="if-elsif-else statement" toReformat="true" toShortenFQNames="false">
         <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
         <variable name="TEST2" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
         <variable name="CMD2" expression="" defaultValue="&quot;echo&quot;" alwaysStopAt="true"/>
@@ -72,7 +72,7 @@
             <option name="OTHER" value="false"/>
         </context>
     </template>
-    <template name="for-each-in" value="for $LOOPVAR$ in $LOOPITEMS$ ; do&#10;    $SELECTION$$END$&#10;done&#10;"
+    <template name="for-each-in" value="for $LOOPVAR$ in $LOOPITEMS$ ; do&#10;    $END$$SELECTION$&#10;done&#10;"
               description="&quot;For each in set&quot; loop" toReformat="true" toShortenFQNames="false">
         <variable name="LOOPVAR" expression="" defaultValue="&quot;VAR&quot;" alwaysStopAt="true"/>
         <variable name="LOOPITEMS" expression="" defaultValue="&quot;item1 item2 item3&quot;" alwaysStopAt="true"/>
@@ -82,7 +82,7 @@
         </context>
     </template>
     <template name="for-index"
-              value="for (( $LOOPVAR$ = $LOOPSTART$; $LOOPVAR$ &lt; $LOOPLIMIT$; ++$LOOPVAR$ )); do&#10;    $SELECTION$$END$&#10;done&#10;"
+              value="for (( $LOOPVAR$ = $LOOPSTART$; $LOOPVAR$ &lt; $LOOPLIMIT$; ++$LOOPVAR$ )); do&#10;    $END$$SELECTION$&#10;done&#10;"
               description="C-style &quot;for&quot; loop" toReformat="true" toShortenFQNames="false">
         <variable name="LOOPVAR" expression="" defaultValue="&quot;VAR&quot;" alwaysStopAt="true"/>
         <variable name="LOOPSTART" expression="" defaultValue="&quot;0&quot;" alwaysStopAt="true"/>
@@ -92,7 +92,7 @@
             <option name="OTHER" value="false"/>
         </context>
     </template>
-    <template name="until" value="until $TEST$; do&#10;    $SELECTION$$END$&#10;done" description="until-loop" toReformat="false"
+    <template name="until" value="until $TEST$; do&#10;    $END$$SELECTION$&#10;done" description="until-loop" toReformat="true"
               toShortenFQNames="false">
         <variable name="TEST" expression="" defaultValue="" alwaysStopAt="true"/>
         <context>
@@ -100,7 +100,7 @@
             <option name="OTHER" value="false"/>
         </context>
     </template>
-    <template name="while" value="while $TEST$; do&#10;    $SELECTION$$END$&#10;done" description="while-loop" toReformat="false"
+    <template name="while" value="while $TEST$; do&#10;    $END$$SELECTION$&#10;done" description="while-loop" toReformat="true"
               toShortenFQNames="false">
         <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
         <context>

--- a/resources/liveTemplates/Bash.xml
+++ b/resources/liveTemplates/Bash.xml
@@ -1,38 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templateSet group="Bash">
-    <template name="if" value="if $TEST$; then&#10;    $SELECTION$$END$&#10;fi" description="if statement" toReformat="false"
-              toShortenFQNames="false">
-        <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
-        <context>
-            <option name="Bash" value="true"/>
-            <option name="OTHER" value="false"/>
-        </context>
-    </template>
-    <template name="ife" value="if $TEST$; then&#10;    $SELECTION$$END$&#10;else&#10;    $CMD$&#10;fi"
-              description="if-else statement" toReformat="false" toShortenFQNames="false">
-        <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
-        <variable name="CMD" expression="" defaultValue="&quot;echo&quot;" alwaysStopAt="true"/>
-        <context>
-            <option name="Bash" value="true"/>
-            <option name="OTHER" value="false"/>
-        </context>
-    </template>
-    <template name="while" value="while $TEST$; do&#10;    $SELECTION$$END$&#10;done" description="while-loop" toReformat="false"
-              toShortenFQNames="false">
-        <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
-        <context>
-            <option name="Bash" value="true"/>
-            <option name="OTHER" value="false"/>
-        </context>
-    </template>
-    <template name="until" value="until $TEST$; do&#10;    $SELECTION$$END$&#10;done" description="until-loop" toReformat="false"
-              toShortenFQNames="false">
-        <variable name="TEST" expression="" defaultValue="" alwaysStopAt="true"/>
-        <context>
-            <option name="Bash" value="true"/>
-            <option name="OTHER" value="false"/>
-        </context>
-    </template>
     <template name="she" value="#!$ENV$ $BASH$" description="shebang line" toReformat="false" toShortenFQNames="false">
         <variable name="ENV" expression="" defaultValue="&quot;/usr/bin/env&quot;" alwaysStopAt="false"/>
         <variable name="BASH" expression="enum(&quot;bash&quot;,&quot;sh&quot;)" defaultValue="" alwaysStopAt="true"/>
@@ -76,6 +43,23 @@
             <option name="OTHER" value="false"/>
         </context>
     </template>
+    <template name="if" value="if $TEST$; then&#10;    $SELECTION$$END$&#10;fi" description="if statement" toReformat="false"
+              toShortenFQNames="false">
+        <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
+        <context>
+            <option name="Bash" value="true"/>
+            <option name="OTHER" value="false"/>
+        </context>
+    </template>
+    <template name="ife" value="if $TEST$; then&#10;    $SELECTION$$END$&#10;else&#10;    $CMD$&#10;fi"
+              description="if-else statement" toReformat="false" toShortenFQNames="false">
+        <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
+        <variable name="CMD" expression="" defaultValue="&quot;echo&quot;" alwaysStopAt="true"/>
+        <context>
+            <option name="Bash" value="true"/>
+            <option name="OTHER" value="false"/>
+        </context>
+    </template>
     <template name="ifee"
               value="if $TEST$; then&#10;    $SELECTION$$END$&#10;elif $TEST2$; then&#10;    $CMD2$&#10;else&#10;    $CMD3$&#10;fi"
               description="if-elsif-else statement" toReformat="false" toShortenFQNames="false">
@@ -103,6 +87,22 @@
         <variable name="LOOPVAR" expression="" defaultValue="&quot;VAR&quot;" alwaysStopAt="true"/>
         <variable name="LOOPSTART" expression="" defaultValue="&quot;0&quot;" alwaysStopAt="true"/>
         <variable name="LOOPLIMIT" expression="" defaultValue="&quot;${LOOP_LIMIT}&quot;" alwaysStopAt="true"/>
+        <context>
+            <option name="Bash" value="true"/>
+            <option name="OTHER" value="false"/>
+        </context>
+    </template>
+    <template name="until" value="until $TEST$; do&#10;    $SELECTION$$END$&#10;done" description="until-loop" toReformat="false"
+              toShortenFQNames="false">
+        <variable name="TEST" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="Bash" value="true"/>
+            <option name="OTHER" value="false"/>
+        </context>
+    </template>
+    <template name="while" value="while $TEST$; do&#10;    $SELECTION$$END$&#10;done" description="while-loop" toReformat="false"
+              toShortenFQNames="false">
+        <variable name="TEST" expression="" defaultValue="&quot;test&quot;" alwaysStopAt="true"/>
         <context>
             <option name="Bash" value="true"/>
             <option name="OTHER" value="false"/>


### PR DESCRIPTION
* Extended live templates with "surround" support for: if, if-else, if-elsif-else, until, while
* Systematized parameter names in conditional and loop constructs, and fixed one or two missing or bad default values
* Sorted alphabetically live templates capable of "surround" so when applying it (CTRL+ALT-j or CTRL+ALT+t) the templates are shown sorted. When just inserting a template (CTRL+j) the templates were already sorted. That different behaviour seems to be an IDEA glitch.