### PR TITLE
Add a project-wide default interpreter path

### DIFF
--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -2,11 +2,11 @@
 <project version="4">
   <component name="Palette2">
     <group name="Swing">
-      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.png" removable="false" auto-create-binding="false" can-attach-label="false">
-        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
-      </item>
       <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.png" removable="false" auto-create-binding="false" can-attach-label="false">
         <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
       </item>
       <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.png" removable="false" auto-create-binding="false" can-attach-label="false">
         <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
@@ -118,6 +118,11 @@
       </item>
       <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.png" removable="false" auto-create-binding="true" can-attach-label="false">
         <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+    <group name="BashSupport">
+      <item class="com.intellij.openapi.ui.TextFieldWithBrowseButton" icon="/com/intellij/uiDesigner/icons/panel.png" removable="true" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="0" />
       </item>
     </group>
   </component>

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+#### 2018-11-02:
+  - [#478](https://github.com/BashSupport/BashSupport/issues/478): New setting for project wide interpreter path
+  - [#487](https://github.com/BashSupport/BashSupport/issues/487): Use native path for shell script and working directory for new Bash run configurations
+
 #### 2018-10-25:
  - [#521](https://github.com/BashSupport/BashSupport/issues/521): control+j does not offer for loop solutions (contributed by t0r0X)
 

--- a/build-all-branches.bash
+++ b/build-all-branches.bash
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 . $HOME/.jdk8
 
-for v in 182.2574.2 181.2784.17 173.2290.1 172.1909.2 171.1834.9 163.3094.26 162.74.16 145.184.1; do
+for v in 2017.2.6 2017.1.6 2016.3.8 2016.2.5 2016.1.4; do
+#for v in 183.3283.2 2018.2.3 2018.1.6 2017.3.5 2017.2.6 2017.1.6 2016.3.8 2016.2.5 2016.1.4; do
     echo "## Building with version $v..."
-    _JAVA_OPTIONS="" JAVA_OPTS="" gradle -Dbash.skipUrls="true" -PideaVersion="$v" clean build
+    _JAVA_OPTIONS="" JAVA_OPTS="" gradle -Dbash.skipUrls="true" -PideaVersion="$v" -PideaBranch="" clean build
 
     status=$?
     if [ $status -ne 0 ]; then

--- a/src/com/ansorgit/plugins/bash/runner/BashConfigForm.java
+++ b/src/com/ansorgit/plugins/bash/runner/BashConfigForm.java
@@ -45,7 +45,9 @@ public class BashConfigForm extends CommonProgramParametersPanel {
     public BashConfigForm(@Nullable Module module) {
         super(false); // no early init
 
-        setModuleContext(module);
+        if (module != null) {
+            setModuleContext(module);
+        }
         init();
     }
 

--- a/src/com/ansorgit/plugins/bash/runner/BashConfigForm.java
+++ b/src/com/ansorgit/plugins/bash/runner/BashConfigForm.java
@@ -18,7 +18,6 @@ package com.ansorgit.plugins.bash.runner;
 import com.intellij.execution.ui.CommonProgramParametersPanel;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
-import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.LabeledComponent;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
@@ -26,7 +25,6 @@ import com.intellij.ui.MacroAwareTextBrowseFolderListener;
 import com.intellij.ui.RawCommandLineEditor;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.util.ui.UIUtil;
-import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
@@ -41,15 +39,6 @@ public class BashConfigForm extends CommonProgramParametersPanel {
 
     private LabeledComponent<JComponent> scriptNameComponent;
     private TextFieldWithBrowseButton scriptNameField;
-
-    public BashConfigForm(@Nullable Module module) {
-        super(false); // no early init
-
-        if (module != null) {
-            setModuleContext(module);
-        }
-        init();
-    }
 
     @Override
     public void setAnchor(JComponent anchor) {

--- a/src/com/ansorgit/plugins/bash/runner/BashConfigForm.java
+++ b/src/com/ansorgit/plugins/bash/runner/BashConfigForm.java
@@ -18,10 +18,15 @@ package com.ansorgit.plugins.bash.runner;
 import com.intellij.execution.ui.CommonProgramParametersPanel;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.LabeledComponent;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.ui.MacroAwareTextBrowseFolderListener;
 import com.intellij.ui.RawCommandLineEditor;
+import com.intellij.ui.components.JBCheckBox;
+import com.intellij.util.ui.UIUtil;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
@@ -31,54 +36,88 @@ public class BashConfigForm extends CommonProgramParametersPanel {
     private LabeledComponent<JComponent> interpreterPathComponent;
     private TextFieldWithBrowseButton interpreterPathField;
 
+    private JBCheckBox projectInterpreterCheckbox;
+    private LabeledComponent<JBCheckBox> projectInterpreterLabeled;
+
     private LabeledComponent<JComponent> scriptNameComponent;
     private TextFieldWithBrowseButton scriptNameField;
 
-    public BashConfigForm() {
+    public BashConfigForm(@Nullable Module module) {
+        super(false); // no early init
+
+        setModuleContext(module);
+        init();
+    }
+
+    @Override
+    public void setAnchor(JComponent anchor) {
+        super.setAnchor(anchor);
+        projectInterpreterCheckbox.setAnchor(anchor);
+        interpreterParametersComponent.setAnchor(anchor);
+        interpreterPathComponent.setAnchor(anchor);
+        scriptNameComponent.setAnchor(anchor);
+    }
+
+    @Override
+    protected void setupAnchor() {
+        super.setupAnchor();
+        myAnchor = UIUtil.mergeComponentsWithAnchor(this, projectInterpreterLabeled, interpreterParametersComponent, interpreterPathComponent, scriptNameComponent);
     }
 
     protected void initOwnComponents() {
-        interpreterParametersComponent = LabeledComponent.create(new RawCommandLineEditor(), "Interpreter options");
-        interpreterParametersComponent.setLabelLocation(BorderLayout.WEST);
+        Project project = getProject();
 
         FileChooserDescriptor chooseInterpreterDescriptor = FileChooserDescriptorFactory.createSingleLocalFileDescriptor();
-        chooseInterpreterDescriptor.setTitle("Choose interpreter...");
+        chooseInterpreterDescriptor.setTitle("Choose Interpreter...");
 
         interpreterPathField = new TextFieldWithBrowseButton();
-        interpreterPathField.addBrowseFolderListener(new MacroAwareTextBrowseFolderListener(chooseInterpreterDescriptor, getProject()));
+        interpreterPathField.addBrowseFolderListener(new MacroAwareTextBrowseFolderListener(chooseInterpreterDescriptor, project));
+
         interpreterPathComponent = LabeledComponent.create(createComponentWithMacroBrowse(interpreterPathField), "Interpreter path:");
         interpreterPathComponent.setLabelLocation(BorderLayout.WEST);
 
+        projectInterpreterCheckbox = new JBCheckBox();
+        projectInterpreterCheckbox.setToolTipText("If enabled then the interpreter path configured in the project settings will be used instead of a custom location.");
+        projectInterpreterCheckbox.addChangeListener(e -> {
+            boolean selected = projectInterpreterCheckbox.isSelected();
+            UIUtil.setEnabled(interpreterPathComponent, !selected, true);
+        });
+        projectInterpreterLabeled = LabeledComponent.create(projectInterpreterCheckbox, "Use project interpreter");
+        projectInterpreterLabeled.setLabelLocation(BorderLayout.WEST);
 
-        FileChooserDescriptor chooseScriptDescriptor = FileChooserDescriptorFactory.createSingleLocalFileDescriptor();
+        interpreterParametersComponent = LabeledComponent.create(new RawCommandLineEditor(), "Interpreter options");
+        interpreterParametersComponent.setLabelLocation(BorderLayout.WEST);
+
         scriptNameField = new TextFieldWithBrowseButton();
-        scriptNameField.addBrowseFolderListener(new MacroAwareTextBrowseFolderListener(chooseScriptDescriptor, getProject()));
+        scriptNameField.addBrowseFolderListener(new MacroAwareTextBrowseFolderListener(FileChooserDescriptorFactory.createSingleLocalFileDescriptor(), project));
 
         scriptNameComponent = LabeledComponent.create(createComponentWithMacroBrowse(scriptNameField), "Script:");
         scriptNameComponent.setLabelLocation(BorderLayout.WEST);
     }
-
 
     @Override
     protected void addComponents() {
         initOwnComponents();
 
         add(scriptNameComponent);
+        add(projectInterpreterLabeled);
         add(interpreterPathComponent);
         add(interpreterParametersComponent);
 
         super.addComponents();
     }
 
-    public void resetBash(BashRunConfiguration configuration) {
-        interpreterParametersComponent.getComponent().setText(configuration.getInterpreterOptions());
+    public void resetFormTo(BashRunConfiguration configuration) {
+        projectInterpreterCheckbox.setSelected(configuration.isUseProjectInterpreter());
         interpreterPathField.setText(configuration.getInterpreterPath());
+        interpreterParametersComponent.getComponent().setText(configuration.getInterpreterOptions());
         scriptNameField.setText(configuration.getScriptName());
     }
 
-    public void applyBashTo(BashRunConfiguration configuration) {
-        configuration.setInterpreterOptions(interpreterParametersComponent.getComponent().getText());
+    public void applySettingsTo(BashRunConfiguration configuration) {
+        configuration.setUseProjectInterpreter(projectInterpreterCheckbox.isSelected());
         configuration.setInterpreterPath(interpreterPathField.getText());
+        configuration.setInterpreterOptions(interpreterParametersComponent.getComponent().getText());
         configuration.setScriptName(scriptNameField.getText());
     }
 }

--- a/src/com/ansorgit/plugins/bash/runner/BashConfigurationType.java
+++ b/src/com/ansorgit/plugins/bash/runner/BashConfigurationType.java
@@ -66,9 +66,8 @@ public class BashConfigurationType extends ConfigurationTypeBase implements Poss
         @NotNull
         @Override
         public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
-            BashRunConfiguration configuration = new BashRunConfiguration(new RunConfigurationModule(project), this, "");
-            configuration.setInterpreterPath(BashInterpreterDetection.instance().findBestLocation());
-
+            BashRunConfiguration configuration = new BashRunConfiguration("", new RunConfigurationModule(project), this);
+            configuration.setUseProjectInterpreter(true);
             return configuration;
         }
     }

--- a/src/com/ansorgit/plugins/bash/runner/BashRunConfigProducer.java
+++ b/src/com/ansorgit/plugins/bash/runner/BashRunConfigProducer.java
@@ -24,6 +24,8 @@ import com.intellij.execution.actions.RunConfigurationProducer;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.io.FileUtilRt;
+import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -52,19 +54,18 @@ public class BashRunConfigProducer extends RunConfigurationProducer<BashRunConfi
         if (!(psiFile instanceof BashFile)) {
             return false;
         }
+        sourceElement.set(psiFile);
 
         VirtualFile file = location.getVirtualFile();
         if (file == null) {
             return false;
         }
 
-        sourceElement.set(psiFile);
-
-        configuration.setName(location.getVirtualFile().getPresentableName());
-        configuration.setScriptName(file.getPath());
+        configuration.setName(file.getPresentableName());
+        configuration.setScriptName(VfsUtilCore.virtualToIoFile(file).getAbsolutePath());
 
         if (file.getParent() != null) {
-            configuration.setWorkingDirectory(file.getParent().getPath());
+            configuration.setWorkingDirectory(VfsUtilCore.virtualToIoFile(file.getParent()).getAbsolutePath());
         }
 
         Module module = context.getModule();

--- a/src/com/ansorgit/plugins/bash/runner/BashRunConfigProducer.java
+++ b/src/com/ansorgit/plugins/bash/runner/BashRunConfigProducer.java
@@ -24,11 +24,9 @@ import com.intellij.execution.actions.RunConfigurationProducer;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Bash run config producer which looks at the current context to create a new run configuation.
@@ -51,7 +49,7 @@ public class BashRunConfigProducer extends RunConfigurationProducer<BashRunConfi
         }
 
         PsiFile psiFile = psiElement.getContainingFile();
-        if (psiFile == null || !(psiFile instanceof BashFile)) {
+        if (!(psiFile instanceof BashFile)) {
             return false;
         }
 
@@ -86,12 +84,6 @@ public class BashRunConfigProducer extends RunConfigurationProducer<BashRunConfi
 
                 configuration.setInterpreterOptions(shebang.shellCommandParams());
             }
-        }
-
-        //fallback location if none was found
-        if (StringUtil.isEmptyOrSpaces(configuration.getInterpreterPath())) {
-            String bashPath = BashInterpreterDetection.instance().findBestLocation();
-            configuration.setInterpreterPath(StringUtils.trimToEmpty(bashPath));
         }
 
         return true;

--- a/src/com/ansorgit/plugins/bash/runner/BashRunConfigUtil.java
+++ b/src/com/ansorgit/plugins/bash/runner/BashRunConfigUtil.java
@@ -1,5 +1,21 @@
+/*
+ * Copyright (c) Joachim Ansorg, mail@ansorg-it.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.ansorgit.plugins.bash.runner;
 
+import com.ansorgit.plugins.bash.settings.BashProjectSettings;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.util.ProgramParametersUtil;
 import org.jetbrains.annotations.NotNull;
@@ -13,8 +29,15 @@ public final class BashRunConfigUtil {
 
     @NotNull
     public static GeneralCommandLine createCommandLine(String workingDir, BashRunConfiguration runConfig) {
+        String interpreterPath;
+        if (runConfig.isUseProjectInterpreter()) {
+            interpreterPath = BashProjectSettings.storedSettings(runConfig.getProject()).getProjectInterpreter();
+        } else {
+            interpreterPath = runConfig.getInterpreterPath();
+        }
+
         GeneralCommandLine cmd = new GeneralCommandLine();
-        cmd.setExePath(runConfig.getInterpreterPath());
+        cmd.setExePath(interpreterPath);
         cmd.getParametersList().addParametersString(runConfig.getInterpreterOptions());
 
         cmd.addParameter(runConfig.getScriptName());

--- a/src/com/ansorgit/plugins/bash/runner/BashRunConfiguration.java
+++ b/src/com/ansorgit/plugins/bash/runner/BashRunConfiguration.java
@@ -123,10 +123,6 @@ public class BashRunConfiguration extends AbstractRunConfiguration implements Ba
             ProgramParametersUtil.checkWorkingDirectoryExist(this, project, module);
         }
 
-        if (StringUtil.isEmptyOrSpaces(interpreterPath)) {
-            throw new RuntimeConfigurationException("No interpreter path given.");
-        }
-
         if (useProjectInterpreter) {
             BashProjectSettings settings = BashProjectSettings.storedSettings(project);
             String interpreter = settings.getProjectInterpreter();
@@ -139,6 +135,10 @@ public class BashRunConfiguration extends AbstractRunConfiguration implements Ba
                 throw new RuntimeConfigurationException("Project interpreter path is invalid or not readable.");
             }
         } else {
+            if (StringUtil.isEmptyOrSpaces(interpreterPath)) {
+                throw new RuntimeConfigurationException("No interpreter path given.");
+            }
+
             Path interpreterFile = Paths.get(interpreterPath);
             if (!Files.isRegularFile(interpreterFile) || !Files.isReadable(interpreterFile)) {
                 throw new RuntimeConfigurationException("Interpreter path is invalid or not readable.");

--- a/src/com/ansorgit/plugins/bash/runner/BashRunConfigurationEditor.java
+++ b/src/com/ansorgit/plugins/bash/runner/BashRunConfigurationEditor.java
@@ -26,20 +26,19 @@ class BashRunConfigurationEditor extends SettingsEditor<BashRunConfiguration> {
     private BashConfigForm form;
 
     BashRunConfigurationEditor(Module module) {
-        this.form = new BashConfigForm();
-        this.form.setModuleContext(module);
+        this.form = new BashConfigForm(module);
     }
 
     @Override
     protected void resetEditorFrom(BashRunConfiguration runConfiguration) {
         form.reset(runConfiguration);
-        form.resetBash(runConfiguration);
+        form.resetFormTo(runConfiguration);
     }
 
     @Override
     protected void applyEditorTo(BashRunConfiguration runConfiguration) throws ConfigurationException {
         form.applyTo(runConfiguration);
-        form.applyBashTo(runConfiguration);
+        form.applySettingsTo(runConfiguration);
     }
 
     @Override

--- a/src/com/ansorgit/plugins/bash/runner/BashRunConfigurationEditor.java
+++ b/src/com/ansorgit/plugins/bash/runner/BashRunConfigurationEditor.java
@@ -26,7 +26,8 @@ class BashRunConfigurationEditor extends SettingsEditor<BashRunConfiguration> {
     private BashConfigForm form;
 
     BashRunConfigurationEditor(Module module) {
-        this.form = new BashConfigForm(module);
+        this.form = new BashConfigForm();
+        this.form.setModuleContext(module);
     }
 
     @Override

--- a/src/com/ansorgit/plugins/bash/settings/BashProjectSettings.java
+++ b/src/com/ansorgit/plugins/bash/settings/BashProjectSettings.java
@@ -45,6 +45,9 @@ public class BashProjectSettings implements Serializable {
 
     private boolean useTerminalPlugin = false;
 
+    @NotNull
+    private String projectInterpreter = "";
+
     public static BashProjectSettings storedSettings(@NotNull Project project) {
         BashProjectSettingsComponent component = project.getComponent(BashProjectSettingsComponent.class);
         if (component == null) {
@@ -152,6 +155,15 @@ public class BashProjectSettings implements Serializable {
 
     public void setValidateWithCurrentEnv(boolean validateWithCurrentEnv) {
         this.validateWithCurrentEnv = validateWithCurrentEnv;
+    }
+
+    @NotNull
+    public String getProjectInterpreter() {
+        return projectInterpreter;
+    }
+
+    public void setProjectInterpreter(@NotNull String projectInterpreter) {
+        this.projectInterpreter = projectInterpreter;
     }
 }
 

--- a/src/com/ansorgit/plugins/bash/settings/BashProjectSettingsConfigurable.java
+++ b/src/com/ansorgit/plugins/bash/settings/BashProjectSettingsConfigurable.java
@@ -50,7 +50,7 @@ public class BashProjectSettingsConfigurable implements Configurable {
 
     public JComponent createComponent() {
         if (settingsPanel == null) {
-            settingsPanel = new BashProjectSettingsPane();
+            settingsPanel = new BashProjectSettingsPane(project);
         }
 
         return settingsPanel.getPanel();

--- a/src/com/ansorgit/plugins/bash/settings/BashProjectSettingsPane.form
+++ b/src/com/ansorgit/plugins/bash/settings/BashProjectSettingsPane.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.ansorgit.plugins.bash.settings.BashProjectSettingsPane">
-  <grid id="27dc6" binding="settingsPane" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="settingsPane" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="569"/>
+      <xy x="20" y="20" width="500" height="633"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -11,7 +11,7 @@
       <grid id="1ee7d" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <clientProperties>
@@ -89,7 +89,7 @@
       <grid id="5d527" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <clientProperties>
@@ -131,7 +131,7 @@
       <grid id="66516" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <clientProperties>
@@ -174,7 +174,7 @@
       <grid id="ab11d" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <clientProperties>
@@ -195,6 +195,33 @@
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
           </vspacer>
+        </children>
+      </grid>
+      <grid id="57177" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <clientProperties>
+          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
+        </clientProperties>
+        <border type="none" title="Bash interpreter"/>
+        <children>
+          <component id="cd9e3" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="interpreterPath" custom-create="true">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <component id="2a6a3" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Default interpreter:"/>
+            </properties>
+          </component>
         </children>
       </grid>
     </children>

--- a/src/com/ansorgit/plugins/bash/settings/BashProjectSettingsPane.java
+++ b/src/com/ansorgit/plugins/bash/settings/BashProjectSettingsPane.java
@@ -16,6 +16,10 @@
 package com.ansorgit.plugins.bash.settings;
 
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
@@ -28,7 +32,9 @@ import java.util.*;
 /**
  * @author jansorg
  */
-public class BashProjectSettingsPane implements Disposable {
+public class BashProjectSettingsPane extends WithProject implements Disposable {
+    JCheckBox useTerminalPlugin;
+    JCheckBox validateWithCurrentEnv;
     private JPanel settingsPane;
     private JTextArea globalVarList;
     private JCheckBox globalVarAutocompletion;
@@ -39,8 +45,11 @@ public class BashProjectSettingsPane implements Disposable {
     private JCheckBox autocompletePathCommands;
     private JCheckBox globalFunctionVarDefs;
     private JCheckBox enableEvalEscapesCheckbox;
-    JCheckBox useTerminalPlugin;
-    JCheckBox validateWithCurrentEnv;
+    TextFieldWithBrowseButton interpreterPath;
+
+    public BashProjectSettingsPane(Project project) {
+        super(project);
+    }
 
     @SuppressWarnings("BoundFieldAssignment")
     public void dispose() {
@@ -68,6 +77,8 @@ public class BashProjectSettingsPane implements Disposable {
         globalFunctionVarDefs.setSelected(settings.isGlobalFunctionVarDefs());
         validateWithCurrentEnv.setSelected(settings.isValidateWithCurrentEnv());
 
+        interpreterPath.setText(settings.getProjectInterpreter());
+
         //experimental
         useTerminalPlugin.setSelected(settings.isUseTerminalPlugin());
     }
@@ -84,6 +95,8 @@ public class BashProjectSettingsPane implements Disposable {
         settings.setGlobalFunctionVarDefs(globalFunctionVarDefs.isSelected());
         settings.setValidateWithCurrentEnv(validateWithCurrentEnv.isSelected());
 
+        settings.setProjectInterpreter(interpreterPath.getText());
+
         //experimental
         settings.setUseTerminalPlugin(useTerminalPlugin.isSelected());
     }
@@ -99,7 +112,8 @@ public class BashProjectSettingsPane implements Disposable {
                 autocompletePathCommands.isSelected() != settings.isAutocompletePathCommands() ||
                 globalFunctionVarDefs.isSelected() != settings.isGlobalFunctionVarDefs() ||
                 useTerminalPlugin.isSelected() != settings.isUseTerminalPlugin() ||
-                validateWithCurrentEnv.isSelected() != settings.isValidateWithCurrentEnv();
+                validateWithCurrentEnv.isSelected() != settings.isValidateWithCurrentEnv() ||
+                !interpreterPath.getText().equals(settings.getProjectInterpreter());
     }
 
     public JPanel getPanel() {
@@ -119,6 +133,11 @@ public class BashProjectSettingsPane implements Disposable {
     }
 
     private void createUIComponents() {
+        FileChooserDescriptor descriptor = FileChooserDescriptorFactory.createSingleLocalFileDescriptor();
+        descriptor.setTitle("Chooser Bash Interpreter...");
+
+        this.interpreterPath = new TextFieldWithBrowseButton(null, this);
+        this.interpreterPath.addBrowseFolderListener("Choose Bash Interpreter...", null, project, descriptor);
     }
 
     {
@@ -136,12 +155,13 @@ public class BashProjectSettingsPane implements Disposable {
      * @noinspection ALL
      */
     private void $$$setupUI$$$() {
+        createUIComponents();
         settingsPane = new JPanel();
-        settingsPane.setLayout(new GridLayoutManager(5, 1, new Insets(0, 0, 0, 0), -1, -1));
+        settingsPane.setLayout(new GridLayoutManager(6, 1, new Insets(0, 0, 0, 0), -1, -1));
         final JPanel panel1 = new JPanel();
         panel1.setLayout(new GridLayoutManager(4, 1, new Insets(0, 0, 0, 0), -1, -1));
         panel1.putClientProperty("BorderFactoryClass", "com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent");
-        settingsPane.add(panel1, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        settingsPane.add(panel1, new GridConstraints(5, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
         panel1.setBorder(BorderFactory.createTitledBorder("Variables"));
         final JLabel label1 = new JLabel();
         label1.setText("Registered global variables (one variable per line):");
@@ -175,7 +195,7 @@ public class BashProjectSettingsPane implements Disposable {
         final JPanel panel3 = new JPanel();
         panel3.setLayout(new GridLayoutManager(4, 1, new Insets(0, 0, 0, 0), -1, -1));
         panel3.putClientProperty("BorderFactoryClass", "com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent");
-        settingsPane.add(panel3, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
+        settingsPane.add(panel3, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
         panel3.setBorder(BorderFactory.createTitledBorder("Autocompletion"));
         autocompleteInternalVars = new JCheckBox();
         autocompleteInternalVars.setText("Show built-in variables ($PWD, $PATH, ...)");
@@ -191,7 +211,7 @@ public class BashProjectSettingsPane implements Disposable {
         final JPanel panel4 = new JPanel();
         panel4.setLayout(new GridLayoutManager(6, 1, new Insets(0, 0, 0, 0), -1, -1));
         panel4.putClientProperty("BorderFactoryClass", "com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent");
-        settingsPane.add(panel4, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
+        settingsPane.add(panel4, new GridConstraints(4, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
         panel4.setBorder(BorderFactory.createTitledBorder("Experimental features - use at your own risk!"));
         enableFormatterCheckbox = new JCheckBox();
         enableFormatterCheckbox.setText("Enable formatter");
@@ -208,13 +228,22 @@ public class BashProjectSettingsPane implements Disposable {
         final JPanel panel5 = new JPanel();
         panel5.setLayout(new GridLayoutManager(2, 1, new Insets(0, 0, 0, 0), -1, -1));
         panel5.putClientProperty("BorderFactoryClass", "com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent");
-        settingsPane.add(panel5, new GridConstraints(2, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
+        settingsPane.add(panel5, new GridConstraints(3, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
         panel5.setBorder(BorderFactory.createTitledBorder("Validation"));
         validateWithCurrentEnv = new JCheckBox();
         validateWithCurrentEnv.setText("Validate scripts with your current environment");
         panel5.add(validateWithCurrentEnv, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final Spacer spacer3 = new Spacer();
         panel5.add(spacer3, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_VERTICAL, 1, GridConstraints.SIZEPOLICY_WANT_GROW, null, null, null, 0, false));
+        final JPanel panel6 = new JPanel();
+        panel6.setLayout(new GridLayoutManager(1, 2, new Insets(0, 0, 0, 0), -1, -1));
+        panel6.putClientProperty("BorderFactoryClass", "com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent");
+        settingsPane.add(panel6, new GridConstraints(1, 0, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_BOTH, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, 1, null, null, null, 0, false));
+        panel6.setBorder(BorderFactory.createTitledBorder("Bash interpreter"));
+        panel6.add(interpreterPath, new GridConstraints(0, 1, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, null, null, null, 0, false));
+        final JLabel label2 = new JLabel();
+        label2.setText("Default interpreter:");
+        panel6.add(label2, new GridConstraints(0, 0, 1, 1, GridConstraints.ANCHOR_WEST, GridConstraints.FILL_NONE, GridConstraints.SIZEPOLICY_FIXED, 1, null, null, null, 0, false));
     }
 
     /**

--- a/src/com/ansorgit/plugins/bash/settings/WithProject.java
+++ b/src/com/ansorgit/plugins/bash/settings/WithProject.java
@@ -13,24 +13,20 @@
  * limitations under the License.
  */
 
-package com.ansorgit.plugins.bash.runner;
+package com.ansorgit.plugins.bash.settings;
 
-import com.intellij.execution.CommonProgramRunConfigurationParameters;
+import com.intellij.openapi.project.Project;
 
-public interface BashRunConfigurationParams extends CommonProgramRunConfigurationParameters {
-    boolean isUseProjectInterpreter();
+/**
+ * Workaround limitations of the IntelliJ-generated forms. "initComponents()" is called before the constructor, thus
+ * we need to use a super-class to provide a non-null value of the project.
+ *
+ * @author jansorg
+ */
+class WithProject {
+    protected final Project project;
 
-    void setUseProjectInterpreter(boolean useProjectInterpreter);
-
-    String getInterpreterPath();
-
-    void setInterpreterPath(String interpreterPath);
-
-    String getInterpreterOptions();
-
-    void setInterpreterOptions(String options);
-
-    String getScriptName();
-
-    void setScriptName(String scriptName);
+    public WithProject(Project project) {
+        this.project = project;
+    }
 }

--- a/test/com/ansorgit/plugins/bash/runner/BashRunConfigurationTest.java
+++ b/test/com/ansorgit/plugins/bash/runner/BashRunConfigurationTest.java
@@ -32,13 +32,13 @@ public class BashRunConfigurationTest extends LightBashCodeInsightFixtureTestCas
     @Test
     public void testBuildOption() throws Exception {
         //dummy setup
-        BashRunConfiguration config = new BashRunConfiguration(new RunConfigurationModule(getProject()), new ConfigurationFactory(BashConfigurationType.getInstance()) {
+        BashRunConfiguration config = new BashRunConfiguration("Bash", new RunConfigurationModule(getProject()), new ConfigurationFactory(BashConfigurationType.getInstance()) {
             @NotNull
             @Override
             public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
                 return new UnknownRunConfiguration(this, project);
             }
-        }, "Bash");
+        });
 
         Assert.assertFalse("The make step must not be enabled by default", config.isCompileBeforeLaunchAddedByDefault());
     }


### PR DESCRIPTION
- adds a new setting to configure a project wide interpreter path
- uses os-native paths on Windows for new run configurations (path to script and path to working directory)

Closes #478 
Closes #487