### PR TITLE
Fixed 'replace with double brackets' quick fix (fixes #664)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
  - [#657](https://github.com/BashSupport/BashSupport/issues/657): Exception when the arithmetic operator >> was used
  - [#671](https://github.com/BashSupport/BashSupport/issues/671): Ignore/log exception while scanning $PATH, e.g. while a system update is active.
 
+#### 2019-01-29:
+ - [#664](https://github.com/BashSupport/BashSupport/issues/664): fix 'replace with double brackets' quick fix (contributed by bjansen)
+
 #### 2018-12-15:
  - [#645](https://github.com/BashSupport/BashSupport/issues/645): fix NPE in keyword handling
  - [#634](https://github.com/BashSupport/BashSupport/issues/634): Handle invalid paths in include file inspection

--- a/src/com/ansorgit/plugins/bash/editor/inspections/quickfix/DoubleBracketsQuickfix.java
+++ b/src/com/ansorgit/plugins/bash/editor/inspections/quickfix/DoubleBracketsQuickfix.java
@@ -78,8 +78,8 @@ public class DoubleBracketsQuickfix extends LocalQuickFixAndIntentionActionOnPsi
     }
 
     private enum Replacement {
-        AND("-a", "&&"),
-        OR("-o", "||"),
+        AND("(?<!\\S)-a(?!\\S)", "&&"),
+        OR("(?<!\\S)-o(?!\\S)", "||"),
         LESS_THAN("\\\\<", "<"),
         MORE_THAN("\\\\>", ">"),
         LEFT_PARANTHESIS("\\\\\\(", "("),

--- a/testData/quickfixes/doubleBracketsQuickfix/after8.bash
+++ b/testData/quickfixes/doubleBracketsQuickfix/after8.bash
@@ -1,0 +1,4 @@
+# "Replace with double brackets" "true"
+if [[ ! -f a/b-a-o.jar ]]; then
+    echo ""
+fi

--- a/testData/quickfixes/doubleBracketsQuickfix/before8.bash
+++ b/testData/quickfixes/doubleBracketsQuickfix/before8.bash
@@ -1,0 +1,4 @@
+# "Replace with double brackets" "true"
+if <caret>[ ! -f a/b-a-o.jar ]; then
+    echo ""
+fi


### PR DESCRIPTION
Don't replace occurrences of '-a' and '-o' that are not operators.

Boundaries (`\\b`) don't work here because `-a` and `-o` contain a dash that is not considered as a word character. Instead, I used negative lookaheads to match something like "-a surrounded by something that is not a non-space character".

All tests are green, and I added a new test based on what was reported in #664.