### PR TITLE
Variables declared by readarray are array vars

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
  - [#657](https://github.com/BashSupport/BashSupport/issues/657): Exception when the arithmetic operator >> was used
  - [#671](https://github.com/BashSupport/BashSupport/issues/671): Ignore/log exception while scanning $PATH, e.g. while a system update is active.
 
+#### 2019-02-07:
+ - [PR#668](https://github.com/BashSupport/BashSupport/pull/668): Support `readarray` as alias of `mapfile` (contributed by niknetniko)
+
 #### 2019-01-29:
  - [#664](https://github.com/BashSupport/BashSupport/issues/664): fix 'replace with double brackets' quick fix (contributed by bjansen)
 

--- a/src/com/ansorgit/plugins/bash/lang/psi/impl/vars/BashVarDefImpl.java
+++ b/src/com/ansorgit/plugins/bash/lang/psi/impl/vars/BashVarDefImpl.java
@@ -139,7 +139,7 @@ public class BashVarDefImpl extends BashBaseStubElementImpl<BashVarDefStub> impl
         // - using an array assignment a=(one two)
         // - using declare -a
         // - using typeset -a
-        // - using mapfile
+        // - using mapfile/readarray
         // - using read -a
         // - using local -a
 
@@ -156,6 +156,7 @@ public class BashVarDefImpl extends BashBaseStubElementImpl<BashVarDefStub> impl
             BashCommand command = (BashCommand) parentElement;
 
             return "mapfile".equals(command.getReferencedCommandName())
+                    || "readarray".equals(command.getReferencedCommandName())
                     || isCommandWithParameter(command, commandsWithArrayOption, typeArrayDeclarationParams);
         }
 

--- a/test/com/ansorgit/plugins/bash/editor/inspections/inspections/ArrayUseOfSimpleVarInspectionTest.java
+++ b/test/com/ansorgit/plugins/bash/editor/inspections/inspections/ArrayUseOfSimpleVarInspectionTest.java
@@ -57,6 +57,11 @@ public class ArrayUseOfSimpleVarInspectionTest extends AbstractInspectionTestCas
     }
 
     @Test
+    public void testReadarrayArray() throws Exception {
+        doTest("arrayUseOfSimpleVarInspection/readarrayArray", new SimpleArrayUseInspection());
+    }
+
+    @Test
     public void testArrayParam() throws Exception {
         doTest("arrayUseOfSimpleVarInspection/arrayParam", new SimpleArrayUseInspection());
     }

--- a/testData/psi/inspection/arrayUseOfSimpleVarInspection/readarrayArray/expected.xml
+++ b/testData/psi/inspection/arrayUseOfSimpleVarInspection/readarrayArray/expected.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<problems/>
+

--- a/testData/psi/inspection/arrayUseOfSimpleVarInspection/readarrayArray/src/A.bash
+++ b/testData/psi/inspection/arrayUseOfSimpleVarInspection/readarrayArray/src/A.bash
@@ -1,0 +1,12 @@
+readarray -t FILES < <(find . -type f -iname "*.go"|grep -v '\/vendor\/')
+readarray -t DIRS < <(go list ./... | grep -v '\/vendor\/')
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  errcho "No Go files found."
+  exit 255
+fi
+
+if [ ${#DIRS[@]} -eq 0 ]; then
+  errcho "No Go dirs found."
+  exit 255
+fi


### PR DESCRIPTION
From the Bash help page:
> readarray: readarray [-n count] [-O origin] [-s count] [-t] [-u fd] [-C callback] [-c quantum] [array]
>    Read lines from a file into an array variable.
>
>    A synonym for `mapfile'.

Support for handling vars declared by `mapfile` as arrays was added in #454. I have basically copied that commit, but for `readarray` instead of `mapfile`.