### PR TITLE
#671: Ignore/log exception while scanning $PATH

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 #### 2019-02-08:
  - [#657](https://github.com/BashSupport/BashSupport/issues/657): Exception when the arithmetic operator >> was used
+ - [#671](https://github.com/BashSupport/BashSupport/issues/671): Ignore/log exception while scanning $PATH, e.g. while a system update is active.
 
 #### 2018-12-15:
  - [#645](https://github.com/BashSupport/BashSupport/issues/645): fix NPE in keyword handling

--- a/src/com/ansorgit/plugins/bash/editor/codecompletion/BashPathCompletionService.kt
+++ b/src/com/ansorgit/plugins/bash/editor/codecompletion/BashPathCompletionService.kt
@@ -37,7 +37,7 @@ class BashPathCompletionService() {
         private val LOG = Logger.getInstance("#bash.completion")
 
         @JvmStatic
-        fun getInstance() = ServiceManager.getService(BashPathCompletionService::class.java)
+        fun getInstance() = ServiceManager.getService(BashPathCompletionService::class.java)!!
     }
 
     data class CompletionItem(val filename: String, val path: String)
@@ -81,8 +81,9 @@ class BashPathCompletionService() {
                         }
                     } catch (ex: Exception) {
                         when (ex) {
-                            is InvalidPathException, is IOException, is SecurityException -> LOG.warn("Invalid path detected in \$PATH element $e", ex)
-                            else -> throw ex
+                            is InvalidPathException, is IOException, is SecurityException -> LOG.debug("Invalid path detected in \$PATH element $e", ex)
+                            is FileSystemException -> LOG.debug("Ignoring filesystem exception in \$PATH element $e", ex)
+                            else -> LOG.error("Exception while scanning \$PATH for command names", ex)
                         }
                     }
                 }


### PR DESCRIPTION
Could happen when a system update is removing commands at the same time the scanning is done.
Closes #671 