### PR TITLE
Update version of gradle-intellij plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "0.4.5"
+    id "org.jetbrains.intellij" version "0.4.8"
 }
 
 repositories {


### PR DESCRIPTION
Update to get rid of warnings about failing IJ JDK downloads