### PR TITLE
wip: return early on processCancelled

### DIFF
--- a/src/com/ansorgit/plugins/bash/documentation/BashDocumentationProvider.kt
+++ b/src/com/ansorgit/plugins/bash/documentation/BashDocumentationProvider.kt
@@ -20,6 +20,7 @@ import com.ansorgit.plugins.bash.lang.psi.api.vars.BashVar
 import com.ansorgit.plugins.bash.lang.psi.util.BashPsiUtils
 import com.intellij.lang.documentation.AbstractDocumentationProvider
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.util.SystemInfoRt
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -87,6 +88,10 @@ class BashDocumentationProvider : AbstractDocumentationProvider() {
      */
     override fun generateDoc(element: PsiElement?, originalElement: PsiElement?): String? {
         for (source in sourceList) {
+            if (ProgressManager.getInstance().hasProgressIndicator()) {
+                ProgressManager.checkCanceled()
+            }
+
             val doc = source.documentation(element, originalElement)
             if (StringUtils.stripToNull(doc) != null) {
                 return doc


### PR DESCRIPTION
This needs more fixes.
19x.x throw an error if a process is executed in a read action. A read action is always used for documentation lookup. We have to work around this or find a way to implement a cancellable info page lookup.

Closes https://github.com/BashSupport/BashSupport/issues/748