### PR TITLE
#735: properly resolve variables declared in a for loop

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+#### 2019-07-15:
+ - [#735](https://github.com/BashSupport/BashSupport/issues/735): Variables which were first declared in a loop were not properly resolved, renamed, and highlighted
+
 #### 2019-06-21:
  - [#682](https://github.com/BashSupport/BashSupport/issues/682): Parse heredocs in pipeline commands
  - [#662](https://github.com/BashSupport/BashSupport/issues/662): Enter handler to insert a line continuation in Bash files

--- a/src/com/ansorgit/plugins/bash/lang/psi/stubs/index/BashIndexVersion.java
+++ b/src/com/ansorgit/plugins/bash/lang/psi/stubs/index/BashIndexVersion.java
@@ -19,7 +19,7 @@ package com.ansorgit.plugins.bash.lang.psi.stubs.index;
  * Configures the versions of the available Bash indexes.
  */
 public final class BashIndexVersion {
-    private static final int BASE = 58;
+    private static final int BASE = 59;
     public static final int CACHES_VERSION = BASE + 9;
     public static final int STUB_INDEX_VERSION = BASE + 31;
     public static final int ID_INDEX_VERSION = BASE + 19;

--- a/src/com/ansorgit/plugins/bash/lang/psi/util/BashPsiUtils.java
+++ b/src/com/ansorgit/plugins/bash/lang/psi/util/BashPsiUtils.java
@@ -25,6 +25,7 @@ import com.ansorgit.plugins.bash.lang.psi.api.command.BashGenericCommand;
 import com.ansorgit.plugins.bash.lang.psi.api.command.BashIncludeCommand;
 import com.ansorgit.plugins.bash.lang.psi.api.expression.BashSubshellCommand;
 import com.ansorgit.plugins.bash.lang.psi.api.function.BashFunctionDef;
+import com.ansorgit.plugins.bash.lang.psi.api.loops.BashFor;
 import com.ansorgit.plugins.bash.lang.psi.api.vars.BashVar;
 import com.ansorgit.plugins.bash.lang.psi.api.word.BashWord;
 import com.ansorgit.plugins.bash.lang.psi.eval.BashEvalBlock;
@@ -636,6 +637,11 @@ public final class BashPsiUtils {
     }
 
     private static boolean isValidContainer(PsiElement element) {
+        if (element instanceof BashFor) {
+            // variables defined in a for loop are also visiable afterwards
+            return false;
+        }
+
         return element instanceof BashBlock || element instanceof BashFunctionDef || element instanceof BashFile;
     }
 

--- a/test/com/ansorgit/plugins/bash/lang/psi/resolve/VarDefResolveTestCase.java
+++ b/test/com/ansorgit/plugins/bash/lang/psi/resolve/VarDefResolveTestCase.java
@@ -212,6 +212,13 @@ public class VarDefResolveTestCase extends AbstractResolveTest {
         assertIsInvalidVarDef();
     }
 
+
+    @Test
+    public void testIssue735_ForLoopDefResolve() throws Exception {
+        BashVarDef def = assertIsValidVarDef();
+        Assert.assertEquals("This must resolve to the for loop definition", 4, def.getTextOffset());
+    }
+
     protected String getTestDataPath() {
         return BashTestUtils.getBasePath() + "/psi/resolve/varDef/";
     }

--- a/test/com/ansorgit/plugins/bash/lang/psi/resolve/VarResolveTestCase.java
+++ b/test/com/ansorgit/plugins/bash/lang/psi/resolve/VarResolveTestCase.java
@@ -369,6 +369,14 @@ public class VarResolveTestCase extends AbstractResolveTest {
         Assert.assertEquals(1, visited.get());
     }
 
+    @Test
+    public void testIssue735_ForLoopDefResolve() throws Exception {
+        PsiReference ref = configure();
+        PsiElement varDef = ref.resolve();
+        Assert.assertNotNull(varDef);
+        Assert.assertEquals("The variable must resolve to the earliest definition, i.e. the one in the for loop", 4, varDef.getTextOffset());
+    }
+
     protected String getTestDataPath() {
         return BashTestUtils.getBasePath() + "/psi/resolve/var/";
     }

--- a/testData/psi/resolve/var/Issue735_ForLoopDefResolve.bash
+++ b/testData/psi/resolve/var/Issue735_ForLoopDefResolve.bash
@@ -1,0 +1,6 @@
+for VAR in "foo"; do
+  echo ${VAR}
+done
+
+VAR=1
+echo $<ref>VAR

--- a/testData/psi/resolve/varDef/Issue735_ForLoopDefResolve.bash
+++ b/testData/psi/resolve/varDef/Issue735_ForLoopDefResolve.bash
@@ -1,0 +1,5 @@
+for VAR in "foo"; do
+  echo ${VAR}
+done
+
+<ref>VAR=1


### PR DESCRIPTION
variables first declared in a for loop and references outside were not properly resolved, renamed, and highlighted

Closes https://github.com/BashSupport/BashSupport/issues/735