### PR TITLE
#758: Fix completion which were displayed as "Invalid" 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
  - [#696](https://github.com/BashSupport/BashSupport/issues/696): Highlight comments in backtick commands
  - [#735](https://github.com/BashSupport/BashSupport/issues/735): Variables which were first declared in a loop were not properly resolved, renamed, and highlighted
  - [#753](https://github.com/BashSupport/BashSupport/issues/753): Fix NPE in BashRunConfiguration.suggestedName()
+ - [#758](https://github.com/BashSupport/BashSupport/issues/758): Completions often showing "Invalid" as label
 
 #### 2019-06-21:
  - [#682](https://github.com/BashSupport/BashSupport/issues/682): Parse heredocs in pipeline commands

--- a/src/com/ansorgit/plugins/bash/lang/psi/impl/vars/BashVarUtils.java
+++ b/src/com/ansorgit/plugins/bash/lang/psi/impl/vars/BashVarUtils.java
@@ -38,34 +38,36 @@ public class BashVarUtils {
         if (definition.isFunctionScopeLocal()) {
             //the reference is a local variable, check if the candidate is in its scope
             return PsiTreeUtil.isAncestor(definition.findFunctionScope(), referenceElement, false);
-        } else if (referenceElement instanceof BashVarDef && ((BashVarDef) referenceElement).isFunctionScopeLocal()) {
+        }
+
+        if (referenceElement instanceof BashVarDef && ((BashVarDef) referenceElement).isFunctionScopeLocal()) {
             //the candidate is a local definition, check if we are in the
             //fixme check this
             return PsiTreeUtil.isAncestor(definition.findFunctionScope(), referenceElement, false);
-        } else {
-            //we need to check the offset of top-level elements
-            if (referenceElement instanceof BashVar) {
-                BashVar var = (BashVar) referenceElement;
-                BashVarDef referencingDefinition = (BashVarDef) var.getReference().resolve();
+        }
 
-                if (referencingDefinition != null && referencingDefinition.isFunctionScopeLocal()) {
-                    return isInDefinedScope(referencingDefinition, definition);
-                }
-            }
+        //we need to check the offset of top-level elements
+        if (referenceElement instanceof BashVar) {
+            BashVar var = (BashVar) referenceElement;
+            BashVarDef referencingDefinition = (BashVarDef) var.getReference().resolve();
 
-            //make sure that the reference is not a self-reference
-            if (BashPsiUtils.hasContext(referenceElement, definition)) {
-                return false;
-            }
-
-            //variableDefinition may be otherwise valid but may be defined after the variable, i.e. it's invalid
-            //this check is only valid if both are in the same file
-            if (!BashPsiUtils.isValidReferenceScope(referenceElement, definition)) {
-                return false;
+            if (referencingDefinition != null && referencingDefinition.isFunctionScopeLocal()) {
+                return isInDefinedScope(referencingDefinition, definition);
             }
         }
 
-        //none is a local variable
+        //make sure that the reference is not a self-reference
+        if (BashPsiUtils.hasContext(referenceElement, definition)) {
+            return false;
+        }
+
+        //variableDefinition may be otherwise valid but may be defined after the variable, i.e. it's invalid
+        //this check is only valid if both are in the same file
+        if (!BashPsiUtils.isValidReferenceScope(referenceElement, definition)) {
+            return false;
+        }
+
+        // not a local variable
         return true;
     }
 }

--- a/test/com/ansorgit/plugins/bash/codeInsight/completion/VariableNameCompletionProviderTest.java
+++ b/test/com/ansorgit/plugins/bash/codeInsight/completion/VariableNameCompletionProviderTest.java
@@ -116,6 +116,13 @@ public class VariableNameCompletionProviderTest extends AbstractCompletionTest {
     }
 
     @Test
+    public void testIncludedVariablesEmpty() throws Exception {
+        configureByTestName(getBasePath() + "/include.bash");
+
+        checkItems("myVarIsOk", "myVarIsOk2", "includedVarHasOtherPrefix", "myIncludedVarIsOk", "myIncludedVarIsOk2");
+    }
+
+    @Test
     public void testDollarCompletion() throws Exception {
         configureByTestName();
 

--- a/testData/codeInsight/completion/variableNameCompletion/includedVariablesEmpty.bash
+++ b/testData/codeInsight/completion/variableNameCompletion/includedVariablesEmpty.bash
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+myVarIsOk=
+myVarIsOk2=
+
+. include.bash
+
+echo ${<caret>}
+
+myVarIsNotOk=


### PR DESCRIPTION
The original
file must not be referenced by completions items because it's modified
when the user is entering more text with visible completions.

Closes https://github.com/BashSupport/BashSupport/issues/758